### PR TITLE
Images entering viewport due to resize should be rendered.

### DIFF
--- a/addon/mixins/in-viewport.js
+++ b/addon/mixins/in-viewport.js
@@ -46,10 +46,15 @@ export default Mixin.create({
     Ember.$(window).on('scroll.scrollable', function() {
       component._scrollHandler();
     });
+
+    Ember.$(window).on('resize.resizable', function() {
+      component._scrollHandler();
+    });
   }),
 
   _unbindScroll: on('willDestroyElement', function() {
     Ember.$(window).off('.scrollable');
+    Ember.$(window).off('.resizable');
     Ember.$(document).off('.scrollable');
   }),
 });


### PR DESCRIPTION
It seems that the desirable behavior would be to render images revealed by a window resize (as they too have entered the viewport even though it wasn't by scrolling).
