### PR TITLE
add sessionStorage cache

### DIFF
--- a/addon/components/lazy-image.js
+++ b/addon/components/lazy-image.js
@@ -1,7 +1,7 @@
 import Ember           from 'ember';
 import ImageLoadMixin  from '../mixins/image-load';
 import InViewportMixin from '../mixins/in-viewport';
-import cache           from '../models/cache';
+import Cache           from '../lib/cache';
 
 var get         = Ember.get;
 var set         = Ember.set;
@@ -9,6 +9,7 @@ var dasherize   = Ember.String.dasherize;
 var observer    = Ember.observer;
 var computed    = Ember.computed;
 var Component   = Ember.Component;
+var cache       = Cache.create();
 
 export default Component.extend(InViewportMixin, ImageLoadMixin, {
   lazyUrl: "//:0",
@@ -21,19 +22,29 @@ export default Component.extend(InViewportMixin, ImageLoadMixin, {
     var url             = get(this, 'url');
     var cacheKey        = get(this, '_cacheKey');
 
-    if (get(cache, cacheKey)) {
+    if (cacheKey && get(cache, cacheKey)) {
       set(this, 'lazyUrl', url);
     }
 
     if (enteredViewport && lazyUrl === "//:0") {
       set(this, 'lazyUrl', url);
-      set(cache, cacheKey, true);
+      
+      if (cacheKey) {
+        set(cache, cacheKey, true);
+      }
     }
   }).on('didInsertElement'),
 
   _cacheKey: computed('url', function() {
     var url = this.get('url');
+    var key;
 
-    return dasherize(url.replace(/^http[s]?\:\/\/|\.|\//g, ''));
+    if (url) {
+      key = dasherize(url.replace(/^http[s]?\:\/\/|\.|\//g, ''));
+    }
+
+    if (key) {
+      return key;
+    }
   })
 });

--- a/addon/components/lazy-image.js
+++ b/addon/components/lazy-image.js
@@ -1,11 +1,14 @@
 import Ember           from 'ember';
 import ImageLoadMixin  from '../mixins/image-load';
 import InViewportMixin from '../mixins/in-viewport';
+import cache           from '../models/cache';
 
-var get       = Ember.get;
-var set       = Ember.set;
-var observer  = Ember.observer;
-var Component = Ember.Component;
+var get         = Ember.get;
+var set         = Ember.set;
+var dasherize   = Ember.String.dasherize;
+var observer    = Ember.observer;
+var computed    = Ember.computed;
+var Component   = Ember.Component;
 
 export default Component.extend(InViewportMixin, ImageLoadMixin, {
   lazyUrl: "//:0",
@@ -15,9 +18,22 @@ export default Component.extend(InViewportMixin, ImageLoadMixin, {
   setImageUrl: observer('enteredViewport', function() {
     var lazyUrl         = get(this, 'lazyUrl');
     var enteredViewport = get(this, 'enteredViewport');
+    var url             = get(this, 'url');
+    var cacheKey        = get(this, '_cacheKey');
+
+    if (get(cache, cacheKey)) {
+      set(this, 'lazyUrl', url);
+    }
 
     if (enteredViewport && lazyUrl === "//:0") {
-      set(this, 'lazyUrl', get(this, 'url'));
+      set(this, 'lazyUrl', url);
+      set(cache, cacheKey, true);
     }
-  }).on('didInsertElement')
+  }).on('didInsertElement'),
+
+  _cacheKey: computed('url', function() {
+    var url = this.get('url');
+
+    return dasherize(url.replace(/^http[s]?\:\/\/|\.|\//g, ''));
+  })
 });

--- a/addon/components/lazy-image.js
+++ b/addon/components/lazy-image.js
@@ -9,9 +9,9 @@ var dasherize   = Ember.String.dasherize;
 var observer    = Ember.observer;
 var computed    = Ember.computed;
 var Component   = Ember.Component;
-var cache       = Cache.create();
 
 export default Component.extend(InViewportMixin, ImageLoadMixin, {
+  cache: Cache.create(),
   lazyUrl: "//:0",
 
   classNames: ['lazy-image-container'],
@@ -20,6 +20,7 @@ export default Component.extend(InViewportMixin, ImageLoadMixin, {
     var lazyUrl         = get(this, 'lazyUrl');
     var enteredViewport = get(this, 'enteredViewport');
     var url             = get(this, 'url');
+    var cache           = get(this, 'cache');
     var cacheKey        = get(this, '_cacheKey');
 
     if (cacheKey && get(cache, cacheKey)) {
@@ -28,7 +29,7 @@ export default Component.extend(InViewportMixin, ImageLoadMixin, {
 
     if (enteredViewport && lazyUrl === "//:0") {
       set(this, 'lazyUrl', url);
-      
+
       if (cacheKey) {
         set(cache, cacheKey, true);
       }

--- a/addon/lib/cache.js
+++ b/addon/lib/cache.js
@@ -1,0 +1,5 @@
+import StorageObject from 'ember-local-storage/session/object';
+
+export default StorageObject.extend({
+  storageKey: 'ember-lazy-images'
+});

--- a/addon/models/cache.js
+++ b/addon/models/cache.js
@@ -1,5 +1,0 @@
-import LocalStorageObject from 'ember-local-storage/object';
-
-export default LocalStorageObject.create({
-  localStorageKey: 'ember-lazy-images'
-});

--- a/addon/models/cache.js
+++ b/addon/models/cache.js
@@ -1,0 +1,5 @@
+import LocalStorageObject from 'ember-local-storage/object';
+
+export default LocalStorageObject.create({
+  localStorageKey: 'ember-lazy-images'
+});

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "ember-cli-qunit": "0.3.1",
     "ember-cli-uglify": "1.0.1",
     "ember-export-application-global": "^1.0.0",
+    "ember-local-storage": "0.0.1",
     "express": "^4.8.5",
     "glob": "^4.0.5"
   },

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "ember-cli-qunit": "0.3.1",
     "ember-cli-uglify": "1.0.1",
     "ember-export-application-global": "^1.0.0",
-    "ember-local-storage": "0.0.1",
+    "ember-local-storage": "0.0.2",
     "express": "^4.8.5",
     "glob": "^4.0.5"
   },

--- a/tests/unit/components/lazy-image-test.js
+++ b/tests/unit/components/lazy-image-test.js
@@ -4,7 +4,7 @@ import {
   test
 } from 'ember-qunit';
 
-import Cache from 'ember-lazy-image/lib/cache.js';
+import Cache from 'ember-lazy-image/lib/cache';
 
 moduleForComponent('lazy-image', 'LazyImageComponent');
 
@@ -50,9 +50,11 @@ test('it renders default error message if image fails to load', function() {
 });
 
 test('it leverages cache', function() {
-  // Setup sessionStorage and init cache
+  // Setup sessionStorage
   window.sessionStorage.clear();
-  Cache.create();
+  Ember.run(function() {
+    Cache.create();
+  });
 
   expect(1);
 
@@ -62,9 +64,13 @@ test('it leverages cache', function() {
 
   this.append();
 
+  Ember.run(function() {
+    component.set('enteredViewport', true);
+  });
+
   var lazyImages = window.sessionStorage['ember-lazy-images'];
   var cache = lazyImages ? JSON.parse(lazyImages) : lazyImages;
-  
+
   deepEqual(cache, {
     emberjscomimagesteamtdalejpg: true
   });

--- a/tests/unit/components/lazy-image-test.js
+++ b/tests/unit/components/lazy-image-test.js
@@ -4,6 +4,8 @@ import {
   test
 } from 'ember-qunit';
 
+import Cache from 'ember-lazy-image/lib/cache.js';
+
 moduleForComponent('lazy-image', 'LazyImageComponent');
 
 var get = Ember.get;
@@ -45,4 +47,25 @@ test('it renders default error message if image fails to load', function() {
 
   ok(component.$(errorMessageSelector).length > 0, 'error message is correctly rendered');
   ok(component.$(errorMessageSelector + ':contains("' + 'Image failed to load' + '")'), 'default error message is rendered correctly');
+});
+
+test('it leverages cache', function() {
+  // Setup sessionStorage and init cache
+  window.sessionStorage.clear();
+  Cache.create();
+
+  expect(1);
+
+  var component = this.subject({
+    url: 'http://emberjs.com/images/team/tdale.jpg'
+  });
+
+  this.append();
+
+  var lazyImages = window.sessionStorage['ember-lazy-images'];
+  var cache = lazyImages ? JSON.parse(lazyImages) : lazyImages;
+  
+  deepEqual(cache, {
+    emberjscomimagesteamtdalejpg: true
+  });
 });


### PR DESCRIPTION
#2 
@twokul see it as a first draft. I used localStorage for the cache as suggested but in the process i felt like localStorage isn't what we need here. The problem with localStorage is that you have to do the bookkeeping (when browser cache expires, etc.). I'm not familiar with the sessionStorage but i guess it's a better bet. I'll add sessionStorage to ember-local-storage and update the PR later. A plain `Ember.Object` could also be a solution but the data gets lost on a reload. I think sessionStorage is what we want.
What do you think? 