### PR TITLE
do not setViewport if component is destroyed

### DIFF
--- a/addon/mixins/in-viewport.js
+++ b/addon/mixins/in-viewport.js
@@ -15,8 +15,12 @@ export default Mixin.create({
   threshold:       0,
 
   _setViewport: function() {
-    var rect      = this.$()[0].getBoundingClientRect();
+    var rect      = this.$() ? this.$()[0].getBoundingClientRect() : null;
     var threshold = get(this, 'threshold');
+
+    if (!rect) {
+      return;
+    }
 
     this.set('enteredViewport',
       rect.top >= 0 &&


### PR DESCRIPTION
i have an issue when transitioning away from a view with lazy-image and the component is already destroyed but the `scrollTimeout` fires later.