### PR TITLE
pass class names to the <img> element

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,14 @@ Lazy Image supports `width`, `height` and `data-*` attribute bindings.
 {{lazy-image url='http://my-valid-url.com/foo.jpg' width=400 height=400 data-foo-bar=foo.bar.path}}
 ```
 
+### `class` attribute
+
+You can also pass class names for the image element.
+
+```html
+{{lazy-image url='http://my-valid-url.com/foo.jpg' class='foo-bar baz-bar'}}
+```
+
 ## Installation
 
 * `git clone` this repository

--- a/addon/components/lazy-image.js
+++ b/addon/components/lazy-image.js
@@ -19,6 +19,15 @@ export default Component.extend(InViewportMixin, ImageLoadMixin, {
 
   classNames: ['lazy-image-container'],
 
+  concatenatedProperties: ['class'],
+
+  class: ['lazy-image'],
+
+  _classJoin: function() {
+    var classArray = this.get('class'); 
+    this.set('class', classArray.join(' '));
+  }.on('init'),
+
   setupAttributes: on('didInsertElement', function() {
     var img       = this.$('img');
     var component = this;

--- a/app/templates/components/lazy-image.hbs
+++ b/app/templates/components/lazy-image.hbs
@@ -30,7 +30,8 @@
 {{/if}}
 
 {{#if useDimensionsAttrs}}
-  <img class="lazy-image" {{bind-attr src=lazyUrl height=height width=width}} />
+  <img class="{{unbound class}}" {{bind-attr src=lazyUrl height=height width=width}} />
 {{else}}
-  <img class="lazy-image" {{bind-attr src=lazyUrl}} />
+  <img class="{{unbound class}}" {{bind-attr src=lazyUrl}} />
 {{/if}}
+

--- a/tests/unit/components/lazy-image-test.js
+++ b/tests/unit/components/lazy-image-test.js
@@ -17,7 +17,7 @@ var errorMessageSelector   = '.lazy-image-error-message';
 var imageContainerSelector = '.lazy-image-container';
 
 test('it has correct defaults', function(assert) {
-  assert.expect(4);
+  assert.expect(5);
 
   var component = this.subject();
 
@@ -25,6 +25,7 @@ test('it has correct defaults', function(assert) {
   assert.equal(get(component, 'errorThrown'),      false);
   assert.equal(get(component, 'lazyUrl'),          "//:0");
   assert.equal(get(component, 'defaultErrorText'), 'Image failed to load');
+  assert.equal(get(component, 'class'),            'lazy-image');
 });
 
 test('it renders default placeholder', function(assert) {
@@ -115,4 +116,17 @@ test('`data-*` attribute bindings work correctly', function(assert) {
   this.render();
 
   assert.equal(component.$('img').attr('data-person-id'), 1234, 'data attribute is correct');
+});
+
+test('passing class names for the <img> element', function(assert) {
+  assert.expect(1);
+
+  var component = this.subject({
+    class: 'img-responsive image-thumbnail'
+  });
+
+  this.render();
+ 
+  var expected = 'lazy-image img-responsive image-thumbnail';
+  assert.equal(component.$('img').attr('class'), expected);
 });


### PR DESCRIPTION
With this change you can:

    {{lazy-image url='...' imgClassNames='img-responsive'}}

Useful when integrating with a Bootstrap theme. I wasn't sure what a proper name for the property would be, I'm open to change it.