### PR TITLE
update ember-local-storage to 0.0.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   "dependencies": {
     "ember-cli-babel": "^5.0.0",
     "ember-in-viewport": "1.0.0",
-    "ember-local-storage": "0.0.3"
+    "ember-local-storage": "0.0.4"
   },
   "keywords": [
     "ember-addon",


### PR DESCRIPTION
There is a problem with safari in private mode where sessionStorage is exposed but when using setIcon it throws a `QuotaExceededError: DOM Exception 22`. I have fixed that in `0.0.4`. You may release a new version as well.