### PR TITLE
Updated ember-in-viewport to 1.2.0

### DIFF
--- a/addon/components/lazy-image.js
+++ b/addon/components/lazy-image.js
@@ -7,7 +7,6 @@ var on        = Ember.on;
 var get       = Ember.get;
 var set       = Ember.set;
 var keys      = Ember.keys;
-var observer  = Ember.observer;
 var computed  = Ember.computed;
 var dasherize = Ember.String.dasherize;
 var Component = Ember.Component;
@@ -29,18 +28,12 @@ export default Component.extend(InViewportMixin, ImageLoadMixin, {
     set(this, 'class', classArray.join(' '));
   }),
 
-  setupAttributes: on('didInsertElement', function() {
-    var img       = this.$('img');
-    var component = this;
-
-    forEach(keys(component), function(key) {
-      if (key.substr(0, 5) === 'data-' && !key.match(/Binding$/)) {
-        img.attr(key, component.get(key));
-      }
-    });
+  handleDidInsertElement: on('didInsertElement', function() {
+    this._setupAttributes();
+    this._setImageUrl();
   }),
 
-  setImageUrl: on('didInsertElement', (observer('viewportEntered', function() {
+  _setImageUrl: on('didEnterViewport', function() {
     var url             = get(this, 'url');
     var cache           = get(this, '_cache');
     var lazyUrl         = get(this, 'lazyUrl');
@@ -58,7 +51,18 @@ export default Component.extend(InViewportMixin, ImageLoadMixin, {
         set(cache, cacheKey, true);
       }
     }
-  }))),
+  }),
+
+  _setupAttributes: function() {
+    var img       = this.$('img');
+    var component = this;
+
+    forEach(keys(component), function(key) {
+      if (key.substr(0, 5) === 'data-' && !key.match(/Binding$/)) {
+        img.attr(key, component.get(key));
+      }
+    });
+  },
 
   _cacheKey: computed('url', function() {
     var url = this.get('url');

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   },
   "dependencies": {
     "ember-cli-babel": "^5.0.0",
-    "ember-in-viewport": "1.0.0",
+    "ember-in-viewport": "1.2.0",
     "ember-local-storage": "0.0.3"
   },
   "keywords": [

--- a/tests/dummy/config/environment.js
+++ b/tests/dummy/config/environment.js
@@ -20,6 +20,10 @@ module.exports = function(environment) {
     APP: {
       // Here you can pass flags/options to your application instance
       // when it is created
+    },
+
+    viewportConfig: {
+      viewportUseRAF: false
     }
   };
 

--- a/tests/unit/components/lazy-image-test.js
+++ b/tests/unit/components/lazy-image-test.js
@@ -6,7 +6,14 @@ import {
 
 import Cache from 'ember-lazy-image/lib/cache';
 
-moduleForComponent('lazy-image', 'LazyImageComponent');
+moduleForComponent('lazy-image', 'LazyImageComponent', {
+  beforeEach: function() {
+    this.container.register('config:in-viewport', { viewportUseRAF: false }, { instantiate: false });
+
+    // Setup sessionStorage
+    window.sessionStorage.clear();
+  }
+});
 
 var run = Ember.run;
 var get = Ember.get;
@@ -52,9 +59,6 @@ test('it renders default error message if image fails to load', function(assert)
 });
 
 test('it leverages cache', function(assert) {
-  // Setup sessionStorage
-  window.sessionStorage.clear();
-
   run(function() {
     Cache.create();
   });
@@ -69,6 +73,7 @@ test('it leverages cache', function(assert) {
 
   run(function() {
     component.set('viewportEntered', true);
+    component.trigger('didEnterViewport');
   });
 
   var lazyImages = window.sessionStorage['ember-lazy-images'];


### PR DESCRIPTION
This commit updates the ember-in-viewport addon to 1.2.0, and refactors
the lazy-image component to use the `didEnterViewport` hook instead.

Closes #23.