### PR TITLE
ember-in-viewport 2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
   },
   "dependencies": {
     "ember-cli-babel": "^5.0.0",
-    "ember-in-viewport": "^1.2.5",
+    "ember-in-viewport": "^2.0.0",
     "ember-local-storage": "0.0.5"
   },
   "keywords": [


### PR DESCRIPTION
Ember 2.0 has removed EnumerableUtils causing ember-in-viewport to fail
