### PR TITLE
Exclude css styles & fix ember autorun error

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,7 +6,9 @@ module.exports = {
 
   included: function emberLazyImageIncluded(app) {
     this._super.included(app);
-
+    
+    if(app.options.imageLazyLoad && app.options.imageLazyLoad.excludeCss){ return; }
+    
     app.import('vendor/lazy-image/lazy-image.css');
   }
 };


### PR DESCRIPTION
Add to ember-cli-build.js config 

```
 var app = new EmberApp(defaults, {
    ...
    imageLazyLoad: {
      excludeCss: true
    }
}
```

This config will exclude css styles if you need to use the custom styles

Updated:
fix ember autorun error
