### PR TITLE
didInitAttrs is deprecated since Ember 2.x now use init

### DIFF
--- a/addon/mixins/lazy-image.js
+++ b/addon/mixins/lazy-image.js
@@ -26,7 +26,7 @@ export default Mixin.create({
     this._setupAttributes();
   }),
 
-  handleImageUrl: on('didInitAttrs', function() {
+  handleImageUrl: on('init', function() {
     this._setImageUrl();
   }),
 


### PR DESCRIPTION
Supress warning on Ember 2.x